### PR TITLE
Add basic unit tests

### DIFF
--- a/tests/test_convert_qa_to_finetune.py
+++ b/tests/test_convert_qa_to_finetune.py
@@ -1,0 +1,91 @@
+"""
+Example unit tests for the QA conversion utilities.
+Each test includes detailed comments explaining what is being tested
+and demonstrates best practices such as using temporary directories
+and deterministic randomness.
+"""
+import json
+import os
+import random
+import sys
+import tempfile
+from pathlib import Path
+import unittest
+
+# Allow importing modules from the Scripts directory
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'Scripts'))
+
+from convert_qa_to_finetune import convert_qa_to_chat_format, prepare_fine_tuning_data
+
+
+class TestConvertQA(unittest.TestCase):
+    """Unit tests for conversion utilities with instructional comments."""
+
+    def setUp(self):
+        # Create a temporary directory for our test files. Using TemporaryDirectory
+        # ensures files are cleaned up even if a test fails.
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_path = Path(self.temp_dir.name)
+
+        # Sample QA data we'll convert. Each line is a JSON object.
+        self.sample_input = self.temp_path / 'sample_qa.jsonl'
+        with open(self.sample_input, 'w', encoding='utf-8') as f:
+            # A simple question/answer pair
+            f.write(json.dumps({'question': 'Hello?', 'answer': 'Hi'}) + '\n')
+            # Already-formatted chat data should pass through unchanged
+            f.write(json.dumps({
+                'messages': [
+                    {'role': 'user', 'content': 'Ping?'},
+                    {'role': 'assistant', 'content': 'Pong!'}
+                ]
+            }) + '\n')
+
+    def tearDown(self):
+        # Always clean up to avoid leaving temp files on disk.
+        self.temp_dir.cleanup()
+
+    def test_convert_qa_to_chat_format(self):
+        """Ensure QA pairs are converted to OpenAI chat format."""
+        output_file = self.temp_path / 'converted.jsonl'
+        convert_qa_to_chat_format(str(self.sample_input), str(output_file), 'TestDialect')
+
+        lines = [json.loads(l) for l in output_file.read_text().splitlines() if l]
+        self.assertEqual(len(lines), 2)
+
+        first = lines[0]
+        # Expect three messages: system, user, assistant
+        self.assertIn('messages', first)
+        self.assertEqual(len(first['messages']), 3)
+        self.assertEqual(first['messages'][1]['content'], 'Hello?')
+        self.assertEqual(first['messages'][2]['content'], 'Hi')
+
+        second = lines[1]
+        # The second entry already contained messages; it should remain unchanged
+        self.assertEqual(second['messages'][0]['content'], 'Ping?')
+        self.assertEqual(second['messages'][1]['content'], 'Pong!')
+
+    def test_prepare_fine_tuning_data(self):
+        """Verify data is split into train/valid files."""
+        converted = self.temp_path / 'converted.jsonl'
+        convert_qa_to_chat_format(str(self.sample_input), str(converted), 'TestDialect')
+
+        # Seed the RNG so shuffling is deterministic during tests
+        random.seed(0)
+        prepare_fine_tuning_data(str(converted), str(self.temp_path / 'out'), train_ratio=0.5)
+
+        train_file = self.temp_path / 'out_train.jsonl'
+        valid_file = self.temp_path / 'out_valid.jsonl'
+
+        self.assertTrue(train_file.exists())
+        self.assertTrue(valid_file.exists())
+
+        train_lines = train_file.read_text().splitlines()
+        valid_lines = valid_file.read_text().splitlines()
+        # With two total entries and a 0.5 split, each file should have one line
+        self.assertEqual(len(train_lines), 1)
+        self.assertEqual(len(valid_lines), 1)
+
+
+if __name__ == '__main__':
+    # Running tests via `python -m unittest` will execute this file as well.
+    unittest.main()

--- a/tests/test_qa_generator.py
+++ b/tests/test_qa_generator.py
@@ -1,0 +1,61 @@
+"""
+Unit tests for the BilingualQAGenerator class.
+These examples illustrate best practices like stubbing external dependencies
+and verifying that helper methods behave as expected.
+"""
+import json
+import sys
+import tempfile
+from pathlib import Path
+import types
+import unittest
+
+# Provide a minimal stub for the openai module so the import succeeds
+openai_stub = types.SimpleNamespace(OpenAI=object)
+sys.modules.setdefault('openai', openai_stub)
+
+# Make the Scripts directory importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'Scripts'))
+
+from openAI_bilingual_qa_generator import BilingualQAGenerator
+
+
+class TestBilingualQAGenerator(unittest.TestCase):
+    """Tests for dictionary loading and prompt creation."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_path = Path(self.temp_dir.name)
+
+        # Create a small dictionary file with some missing translations
+        self.dict_file = self.temp_path / 'dict.json'
+        entries = [
+            {'word': 'dog', 'translation': 'hound'},
+            {'word': 'cat', 'translation': ''},
+            {'word': 'bird'}  # missing translation key
+        ]
+        self.dict_file.write_text(json.dumps(entries), encoding='utf-8')
+
+        self.output_file = self.temp_path / 'out.jsonl'
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_load_dictionary_filters_missing_translations(self):
+        generator = BilingualQAGenerator('TestDialect', str(self.dict_file), str(self.output_file))
+        # Only one entry has a non-empty translation
+        self.assertEqual(len(generator.dictionary_entries), 1)
+        self.assertEqual(generator.dictionary_entries[0]['word'], 'dog')
+
+    def test_create_context_prompt_contains_entries(self):
+        generator = BilingualQAGenerator('TestDialect', str(self.dict_file), str(self.output_file))
+        prompt = generator.create_context_prompt(generator.dictionary_entries)
+        # Each dictionary entry should be embedded in the prompt text
+        for entry in generator.dictionary_entries:
+            self.assertIn(json.dumps(entry, ensure_ascii=False), prompt)
+        # The dialect name is also referenced in the instructions
+        self.assertIn('TestDialect', prompt)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests for QA conversion helpers
- add unit tests for dictionary loading and prompt creation
- remove compiled test artifacts

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_684f45c70d64832eb0354b9bc4c663fe